### PR TITLE
Add locale and change callback format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # v0.7.2
+## Add optional locale parameter, switch to React style callbacks
+We switch from the '&' syntax to '<' to allow the component to be wrapped with angular2react.
+
+# v0.7.2
 ## Use the real V2 requirements API in the demo page
 
 # v0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.7.2
+# v0.8.0
 ## Add optional locale parameter, switch to React style callbacks
 We switch from the '&' syntax to '<' to allow the component to be wrapped with angular2react.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,23 @@
 {
   "name": "@transferwise/account-details-frontend",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@transferwise/styleguide-components": {
       "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@transferwise/styleguide-components/-/styleguide-components-3.5.5.tgz",
-      "integrity": "sha512-5T1sK97Xaq6TpQKujIOFT4eznbEMvBeDIt7d1cDQOrYzaF3r0a+9+k9k7FfpfrwM73aZKMhofAtcizL+GEYhJA==",
+      "resolved": "https://registry.npmjs.org/@transferwise/styleguide-components/-/styleguide-components-3.5.10.tgz",
+      "integrity": "sha512-MCbFSGaQpts9JzjGodVPr1e1S6LiT01hVBBf8JhRjWOKuR9oRmZvEzpnM91VQJIp0ZB1y6RDsiMhHbE0faT4jg==",
       "requires": {
-        "angular": "^1.5.0",
+        "angular": "~1.5.0",
         "jquery": "^3.2.1"
+      },
+      "dependencies": {
+        "angular": {
+          "version": "1.5.11",
+          "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.11.tgz",
+          "integrity": "sha1-jFunOG8VllyazzQp9ogVU6raMNY="
+        }
       }
     },
     "@uirouter/angularjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "dependencies": {
     "@transferwise/styleguide-components": {
-      "version": "3.5.5",
+      "version": "3.5.10",
       "resolved": "https://registry.npmjs.org/@transferwise/styleguide-components/-/styleguide-components-3.5.5.tgz",
       "integrity": "sha512-5T1sK97Xaq6TpQKujIOFT4eznbEMvBeDIt7d1cDQOrYzaF3r0a+9+k9k7FfpfrwM73aZKMhofAtcizL+GEYhJA==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/account-details-frontend",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "TransferWise components for interacting with Account Details",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/account-details-frontend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "TransferWise components for interacting with Account Details",
   "license": "MIT",
   "scripts": {
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/transferwise/account-details-frontend",
   "dependencies": {
-    "@transferwise/styleguide-components": "^3.5.5",
+    "@transferwise/styleguide-components": "^3.5.10",
     "angular": "^1.7.4",
     "jquery": "^3.3.1"
   },

--- a/src/account-details-create/account-details-create.component.js
+++ b/src/account-details-create/account-details-create.component.js
@@ -8,9 +8,10 @@ const AccountDetailsCreate = {
     currency: '<',
     quoteId: '<',
     profileId: '<',
-    onChange: '&',
-    onSuccess: '&',
-    onFailure: '&',
+    locale: '<',
+    onChange: '<',
+    onSuccess: '<',
+    onFailure: '<',
     saveButtonLabel: '<'
   }
 };

--- a/src/account-details-create/account-details-create.controller.js
+++ b/src/account-details-create/account-details-create.controller.js
@@ -41,7 +41,7 @@ class AccountDetailsCreateController {
   }
 
   $onChanges(changes) {
-    if (changes.currency || changes.locale) {
+    if (changes.currency) {
       this.model.currency = changes.currency.currentValue || 'GBP';
 
       this.AccountDetailsService.getTargetCountries(this.model.currency)

--- a/src/account-details-create/account-details-create.controller.js
+++ b/src/account-details-create/account-details-create.controller.js
@@ -115,8 +115,10 @@ class AccountDetailsCreateController {
   }
 
   saveAccount() {
-    this.AccountDetailsService.save(this.model)
+    this.AccountDetailsService
+      .save(this.model)
       .then(() => {
+        this.errors = {};
         if (this.onSuccess) {
           this.onSuccess();
         }

--- a/src/account-details-create/account-details-create.controller.js
+++ b/src/account-details-create/account-details-create.controller.js
@@ -119,23 +119,17 @@ class AccountDetailsCreateController {
       .save(this.model)
       .then(() => {
         this.errors = {};
-        if (this.onSuccess) {
-          this.onSuccess();
-        }
+        triggerCallback(this.onSuccess);
       })
       .catch((errors) => {
         this.errors = errors;
-        if (this.onFailure) {
-          this.onFailure();
-        }
+        triggerCallback(this.onFailure);
       });
   }
 
   onEmailChange(email) {
     this.model.email = email;
-    if (this.onChange) {
-      this.onChange(this.model);
-    }
+    triggerCallback(this.onChange, this.model);
   }
 
   onUseUniqueId(recipient) {
@@ -146,16 +140,12 @@ class AccountDetailsCreateController {
   }
 
   onFormModelChange(model) {
-    if (this.onChange) {
-      this.onChange(model);
-    }
+    triggerCallback(this.onChange, model);
   }
 
   onCountryChange() {
     this.refreshRequirements();
-    if (this.onChange) {
-      this.onChange(this.model);
-    }
+    triggerCallback(this.onChange, this.model);
   }
 
   isCountrySelectorVisible() {
@@ -167,6 +157,12 @@ class AccountDetailsCreateController {
 
   isAccountFormVisible() {
     return !this.uniqueIdRecipient && this.hasDetails;
+  }
+}
+
+function triggerCallback(callback, data) {
+  if (typeof callback === 'function') {
+    callback(data);
   }
 }
 

--- a/src/account-details-create/account-details-create.html
+++ b/src/account-details-create/account-details-create.html
@@ -19,6 +19,7 @@
 </div>
 
 <account-email-lookup
+  locale="$ctrl.locale"
   on-change="$ctrl.onEmailChange(email)"
   on-use-unique-id="$ctrl.onUseUniqueId(recipient)"
   on-enter-manually="$ctrl.onEnterManually()"

--- a/src/account-details-create/account-details-create.html
+++ b/src/account-details-create/account-details-create.html
@@ -32,7 +32,7 @@
   <tw-select
     ng-model="$ctrl.model.country"
     options="$ctrl.targetCountries"
-    ng-change="$ctrl.refreshRequirements()"
+    ng-change="$ctrl.onCountryChange()"
     name="targetCountry"
   ></tw-select>
 </div>
@@ -47,6 +47,7 @@
   <tw-requirements-form
     ng-if="$ctrl.alternatives"
     model="$ctrl.model"
+    on-model-change="$ctrl.onFormModelChange(model)"
     requirements="$ctrl.alternatives"
     error-messages="$ctrl.errors"
     validation-messages="$ctrl.translations.validation"

--- a/src/account-details-create/account-details-create.spec.js
+++ b/src/account-details-create/account-details-create.spec.js
@@ -13,8 +13,8 @@ describe('Given a component for creating accounts', function() {
       currency='currency' \
       quote-id='quoteId' \
       locale='locale' \
-      on-success='onSuccess()' \
-      on-failure='onFailure()' \
+      on-success='onSuccess' \
+      on-failure='onFailure' \
       save-button-label='saveButtonLabel'> \
     </account-details-create>";
 

--- a/src/account-details-create/account-details-create.spec.js
+++ b/src/account-details-create/account-details-create.spec.js
@@ -12,6 +12,7 @@ describe('Given a component for creating accounts', function() {
     <account-details-create \
       currency='currency' \
       quote-id='quoteId' \
+      locale='locale' \
       on-success='onSuccess()' \
       on-failure='onFailure()' \
       save-button-label='saveButtonLabel'> \
@@ -49,6 +50,7 @@ describe('Given a component for creating accounts', function() {
       .and.returnValue($q.resolve(alternatives));
 
     $scope.currency = 'GBP';
+    $scope.locale = 'fr-FR';
     $scope.saveButtonLabel = 'Button Label';
     $scope.onSuccess = jasmine.createSpy('onSuccess');
     $scope.onFailure = jasmine.createSpy('onFailure');
@@ -60,7 +62,7 @@ describe('Given a component for creating accounts', function() {
     });
 
     it('should load the requirements from the account details service with the given currency', function() {
-      expect(AccountDetailsService.getRequirements).toHaveBeenCalledWith('GBP', undefined);
+      expect(AccountDetailsService.getRequirements).toHaveBeenCalledWith('GBP', 'fr-FR', undefined);
       expect(AccountDetailsService.getRequirements.calls.count()).toBe(1);
     });
 
@@ -79,7 +81,7 @@ describe('Given a component for creating accounts', function() {
       });
 
       it('should refresh the requirements via account details service', function() {
-        expect(AccountDetailsService.getRequirements).toHaveBeenCalledWith('GBP', undefined);
+        expect(AccountDetailsService.getRequirements).toHaveBeenCalledWith('GBP', 'fr-FR', undefined);
       });
     });
 
@@ -195,11 +197,15 @@ describe('Given a component for creating accounts', function() {
             angular.element(targetCountrySelect).controller('ngModel').$setViewValue('CA');
           });
           it('should refresh the requirements with the country', function() {
-            expect(AccountDetailsService.refreshRequirements).toHaveBeenCalledWith('USD', {
-              currency: 'USD',
-              country: 'CA',
-              type: alternatives.data[0].type
-            });
+            expect(AccountDetailsService.refreshRequirements).toHaveBeenCalledWith(
+              'USD',
+              {
+                currency: 'USD',
+                country: 'CA',
+                type: alternatives.data[0].type
+              },
+              'fr-FR'
+            );
           });
         });
       });
@@ -225,7 +231,9 @@ describe('Given a component for creating accounts', function() {
         $scope.$apply();
       });
       it('should request the new requirements', function() {
-        expect(AccountDetailsService.getRequirementsForQuote).toHaveBeenCalledWith(123, 'GBP');
+        expect(AccountDetailsService.getRequirementsForQuote).toHaveBeenCalledWith(
+          123, 'GBP', 'fr-FR'
+        );
       });
     });
   });

--- a/src/account-details-create/demo.html
+++ b/src/account-details-create/demo.html
@@ -7,9 +7,10 @@
         currency.</p>
 <pre>
 &lt;account-details-create
-  currency="'USD'"
-  quote-id="..."
   profile-id="..."
+  currency="'USD'"
+  locale="'fr-FR'"
+  quote-id="..."
   on-change="myChangeHandler(model)"
   on-save-success="mySuccessHandler()"
   on-save-failure="myFailureHandler()"
@@ -18,16 +19,19 @@
 </pre>
 
       <dl class="dl-horizontal">
+        <dt>profileID</dt>
+        <dd>Which profile will own this account.</dd>
+
         <dt>currency</dt>
         <dd>3 digit currency code, used to determine the requirements for the new account.</dd>
 
-        <dt>profileID</dt>
-        <dd>Which profile will own this account.</dd>
+        <dt>locale</dt>
+        <dd>(Optional) Which language should we show? Default: en-GB</dd>
 
         <dt>quoteID</dt>
         <dd>
           (Optional) If we're creating a new recipient for a quote, provide the quote id
-          in addition to the currenct.  Occasionally the requirements may change
+          in addition to the currency.  Occasionally the requirements may change
           based on other aspects of the quote (e.g. amount).
         </dd>
 
@@ -56,11 +60,13 @@
       <account-details-create
         currency="'EUR'"
         profile-id="1234"
-        on-change="$ctrl.onModelChange(model)"
-        on-save-success="$ctrl.log('success')"
-        on-save-failure="$ctrl.log('failure')"
+        locale="'fr-FR'"
+        on-change="$ctrl.onModelChange"
+        on-save-success="$ctrl.logSuccess"
+        on-save-failure="$ctrl.logFailure"
         save-button-label="'Save'"
       ></account-details-create>
+
     </div>
   </div>
 </div>

--- a/src/account-details-create/demo.html
+++ b/src/account-details-create/demo.html
@@ -9,7 +9,7 @@
 &lt;account-details-create
   profile-id="..."
   currency="'USD'"
-  locale="'fr-FR'"
+  locale="'{{ $ctrl.locale }}'"
   quote-id="..."
   on-change="myChangeHandler(model)"
   on-save-success="mySuccessHandler()"
@@ -53,6 +53,14 @@
         </dd>
       </dl>
 
+      <div class="form-group">
+        <label class="control-label">Locale</label>
+        <tw-select
+          options="$ctrl.locales"
+          ng-model="$ctrl.locale">
+        </tw-select>
+      </div>
+
       <h4>Internal model</h4>
       <pre>{{ $ctrl.model | json }}</pre>
     </div>
@@ -60,7 +68,7 @@
       <account-details-create
         currency="'EUR'"
         profile-id="1234"
-        locale="'fr-FR'"
+        locale="$ctrl.locale"
         on-change="$ctrl.onModelChange"
         on-save-success="$ctrl.logSuccess"
         on-save-failure="$ctrl.logFailure"

--- a/src/account-details-create/demo.html
+++ b/src/account-details-create/demo.html
@@ -8,15 +8,30 @@
 <pre>
 &lt;account-details-create
   profile-id="..."
-  currency="'USD'"
+  currency="'{{ $ctrl.currency }}'"
   locale="'{{ $ctrl.locale }}'"
   quote-id="..."
   on-change="myChangeHandler(model)"
-  on-save-success="mySuccessHandler()"
-  on-save-failure="myFailureHandler()"
+  on-success="mySuccessHandler()"
+  on-failure="myFailureHandler()"
   save-button-label="'Save'"
 &gt;&lt;/account-details-create&gt;
 </pre>
+
+      <div class="form-group">
+        <label class="control-label">Currency</label>
+        <tw-select
+          options="$ctrl.currencies"
+          ng-model="$ctrl.currency">
+        </tw-select>
+      </div>
+      <div class="form-group">
+        <label class="control-label">Locale</label>
+        <tw-select
+          options="$ctrl.locales"
+          ng-model="$ctrl.locale">
+        </tw-select>
+      </div>
 
       <dl class="dl-horizontal">
         <dt>profileID</dt>
@@ -53,25 +68,17 @@
         </dd>
       </dl>
 
-      <div class="form-group">
-        <label class="control-label">Locale</label>
-        <tw-select
-          options="$ctrl.locales"
-          ng-model="$ctrl.locale">
-        </tw-select>
-      </div>
-
       <h4>Internal model</h4>
       <pre>{{ $ctrl.model | json }}</pre>
     </div>
     <div class="col-md-6">
       <account-details-create
-        currency="'EUR'"
+        currency="$ctrl.currency"
         profile-id="1234"
         locale="$ctrl.locale"
         on-change="$ctrl.onModelChange"
-        on-save-success="$ctrl.logSuccess"
-        on-save-failure="$ctrl.logFailure"
+        on-success="$ctrl.logSuccess"
+        on-failure="$ctrl.logFailure"
         save-button-label="'Save'"
       ></account-details-create>
 

--- a/src/account-details-create/demo.js
+++ b/src/account-details-create/demo.js
@@ -17,6 +17,18 @@ class controller {
       value: 'en-GB',
       label: 'English'
     }];
+
+    this.currency = 'GBP';
+    this.currencies = [{
+      value: 'GBP',
+      label: 'Great British Pounds'
+    }, {
+      value: 'USD',
+      label: 'United States Dollar'
+    }, {
+      value: 'EUR',
+      label: 'Euro'
+    }];
   }
 
   onModelChange(model) { // eslint-disable-line

--- a/src/account-details-create/demo.js
+++ b/src/account-details-create/demo.js
@@ -8,6 +8,15 @@ class controller {
   constructor() {
     ctrl = this;
     ctrl.model = {};
+
+    this.locale = 'en-GB';
+    this.locales = [{
+      value: 'fr-FR',
+      label: 'French'
+    }, {
+      value: 'en-GB',
+      label: 'English'
+    }];
   }
 
   onModelChange(model) { // eslint-disable-line

--- a/src/account-details-create/demo.js
+++ b/src/account-details-create/demo.js
@@ -2,13 +2,23 @@ import angular from 'angular';
 import template from './demo.html';
 import component from './index';
 
+let ctrl;
+
 class controller {
-  onModelChange(model) {
-    this.model = model;
+  constructor() {
+    ctrl = this;
+    ctrl.model = {};
+  }
+
+  onModelChange(model) { // eslint-disable-line
+    ctrl.model = model;
     console.log('model changed', model); // eslint-disable-line
   }
-  log(message) { // eslint-disable-line
-    console.log(message); // eslint-disable-line
+  logSuccess() { // eslint-disable-line
+    console.log('success'); // eslint-disable-line
+  }
+  logFailure() { // eslint-disable-line
+    console.log('failure'); // eslint-disable-line
   }
 }
 

--- a/src/account-details-legacy/account-details-legacy.service.js
+++ b/src/account-details-legacy/account-details-legacy.service.js
@@ -15,7 +15,33 @@ class AccountDetailsLegacyService {
       .prepRequirements(alternatives)
       .filter(alternative => Object.keys(alternative.properties).length > 0);
 
+    const propertiesToRemove = [
+      'fields', // TODO move to requirements service
+      'actions',
+      'dataModel',
+      'image',
+      'label',
+      'prepared',
+      'refreshUrl',
+      'repeatText',
+      'repeatable',
+      'repeatableLabel',
+      'repeatableListItemLabel',
+      'reviewFields'
+    ];
+
     preppedAlternatives.forEach((alternative) => {
+      propertiesToRemove.forEach((property) => {
+        delete alternative[property];
+      });
+
+      // TODO this should not be necessary, for some reason enum isn't lower case
+      // It must be coming from somewhere else.
+      if (alternative.typeString && alternative.properties.type) {
+        alternative.properties.type.enum = [alternative.typeString];
+        delete alternative.typeString;
+      }
+
       const typeExtensions = currencyExtensions[currency]
         && currencyExtensions[currency][alternative.type];
 
@@ -373,6 +399,14 @@ const globalExtensions = {
     postCode: {
       width: 'md'
     }
+  },
+  details: {
+    phoneNumber: {
+      format: 'phone'
+    }
+  },
+  legalEntityType: {
+    control: 'radio'
   }
 };
 

--- a/src/account-details-service/account-details.service.js
+++ b/src/account-details-service/account-details.service.js
@@ -111,7 +111,7 @@ class AccountDetailsService {
 
     const path = '/v2/accounts';
 
-    return this.$http.post(this.domain + path, apiModel, options);
+    return this.$http.post(path, apiModel, options);
   }
 
   /**

--- a/src/account-details-service/account-details.service.js
+++ b/src/account-details-service/account-details.service.js
@@ -13,7 +13,7 @@ class AccountDetailsService {
    * Live calls, use source/sourceAmount for special cases
    * {{host}}/v1/account-requirements?source=EUR&target=USD&sourceAmount=1000
    */
-  getRequirements(currency, country) {
+  getRequirements(currency, locale, country) {
     if (!currency) {
       throw new Error('Currency is required');
     }
@@ -21,7 +21,8 @@ class AccountDetailsService {
     const options = getRequirementsHttpOptions(
       currency,
       this.LegacyService,
-      this.$http
+      this.$http,
+      locale
     );
 
     const path = getRequirementsPath(currency, country);
@@ -36,7 +37,7 @@ class AccountDetailsService {
     return promise;
   }
 
-  getRequirementsForQuote(quoteId, currency, country) {
+  getRequirementsForQuote(quoteId, currency, locale, country) {
     if (!quoteId || !currency) {
       throw new Error('Quote id and currency are required');
     }
@@ -44,7 +45,8 @@ class AccountDetailsService {
     const options = getRequirementsHttpOptions(
       currency,
       this.LegacyService,
-      this.$http
+      this.$http,
+      locale
     );
 
     const path = `/v2/quotes/${quoteId}/account-requirements`;
@@ -62,7 +64,7 @@ class AccountDetailsService {
   /**
    * Refresh account requirments for a currency using an existing model
    */
-  refreshRequirements(currency, model) {
+  refreshRequirements(currency, model, locale) {
     if (!currency) {
       throw new Error('Currency is required');
     }
@@ -71,7 +73,8 @@ class AccountDetailsService {
     const options = getRequirementsHttpOptions(
       currency,
       this.LegacyService,
-      this.$http
+      this.$http,
+      locale
     );
 
     const path = getRequirementsPath(currency, model.country);
@@ -159,8 +162,11 @@ function getRequirementsPath(currency, country) {
  * We use transformers rather than a 'then', as in Angular >1.5, using a 'then'
  * without a catch throws a warning, and we do not want to catch at this point.
  */
-function getRequirementsHttpOptions(currency, LegacyService, $http) {
+function getRequirementsHttpOptions(currency, LegacyService, $http, locale) {
   return {
+    headers: {
+      'Accept-Language': locale
+    },
     transformResponse: getResponseTransformers(
       (data, headers, status) => handleRequirementsResponse(
         currency,

--- a/src/account-details-service/account-details.spec.js
+++ b/src/account-details-service/account-details.spec.js
@@ -191,7 +191,7 @@ describe('Given a service for interacting with the acount details API', function
 
       spyOn(AccountDetailsLegacyService, 'formatModelForAPI').and.returnValue(formattedModel);
       spyOn(AccountDetailsLegacyService, 'formatErrorsForDisplay').and.returnValue(['formatted']);
-      $httpBackend.whenPOST('https://api.transferwise.com/v2/accounts').respond(401, ['errors']);
+      $httpBackend.whenPOST('/v2/accounts').respond(401, ['errors']);
 
       promise = service.save(model);
     });
@@ -203,7 +203,7 @@ describe('Given a service for interacting with the acount details API', function
     });
     it('should POST the formatted model to the API', function() {
       promise.catch(function() {});
-      $httpBackend.expectPOST('https://api.transferwise.com/v2/accounts', formattedModel);
+      $httpBackend.expectPOST('/v2/accounts', formattedModel);
       $httpBackend.flush();
     });
     it('should use the legacy service to format error responses', function() {

--- a/src/account-details-service/account-details.spec.js
+++ b/src/account-details-service/account-details.spec.js
@@ -88,7 +88,7 @@ describe('Given a service for interacting with the acount details API', function
         spyOn(AccountDetailsLegacyService, 'prepareResponse').and.returnValue(['prepared']);
         spyOn(AccountDetailsLegacyService, 'modifyUSD').and.returnValue($q.resolve(['modified']));
 
-        service.getRequirements('USD', 'HK');
+        service.getRequirements('USD', 'fr-FR', 'HK');
       });
       it('should pass the country to the API', function() {
         $httpBackend.expectGET(restGwRequirements + '?targetCurrency=USD&country=HK');

--- a/src/backend.js
+++ b/src/backend.js
@@ -68,11 +68,11 @@ function mockBackend($httpBackend) {
 const accountCreateErrors = [{
   code: 'NOT_VALID',
   message: 'Incorrect value',
-  path: 'sortCode'
+  path: 'details.sortCode'
 }, {
   code: 'REQUIRED',
   message: 'Required',
-  path: 'name'
+  path: 'name.fullName'
 }];
 
 

--- a/src/e2e.spec.js
+++ b/src/e2e.spec.js
@@ -20,7 +20,7 @@ describe('given a system for creating account details, when initialised', functi
 
     $httpBackend.whenGET(path + '/v2/account-requirements?targetCurrency=GBP').respond(requirements);
 
-    $httpBackend.whenPOST(path + '/v2/accounts').respond(function(method, url, data) {
+    $httpBackend.whenPOST('/v2/accounts').respond(function(method, url, data) {
       return [200, data];
     });
   }));
@@ -61,7 +61,7 @@ describe('given a system for creating account details, when initialised', functi
     });
 
     it('should call the API to save the account', function() {
-      $httpBackend.expectPOST(path + '/v2/accounts', {
+      $httpBackend.expectPOST('/v2/accounts', {
         currency: 'GBP',
         type: 'test',
         name: {

--- a/src/email-lookup/email-lookup.component.js
+++ b/src/email-lookup/email-lookup.component.js
@@ -5,6 +5,7 @@ const AccountEmailLookup = {
   controller,
   template,
   bindings: {
+    locale: '<',
     onChange: '&',
     onUseUniqueId: '&',
     onEnterManually: '&'

--- a/src/multi-account-create/demo.html
+++ b/src/multi-account-create/demo.html
@@ -9,7 +9,7 @@
 &lt;multi-account-create
   profile-id="..."
   currency="'EUR'"
-  locale="'fr-FR'"
+  locale="'{{$ctrl.locale}}'"
   on-change="myChangeHandler(model)"
   on-success="mySuccessHandler()"
   on-failure="myFailureHandler()"
@@ -45,6 +45,14 @@
         </dd>
       </dl>
 
+      <div class="form-group">
+        <label class="control-label">Locale</label>
+        <tw-select
+          options="$ctrl.locales"
+          ng-model="$ctrl.locale">
+        </tw-select>
+      </div>
+
       <h4>Internal model</h4>
       <pre>{{ $ctrl.model | json }}</pre>
 
@@ -52,7 +60,7 @@
     <div class="col-md-6">
       <multi-account-create
         currency="'EUR'"
-        locale="'fr-FR'"
+        locale="$ctrl.locale"
         profile-id="1234"
         on-change="$ctrl.onModelChange"
         on-success="$ctrl.logSuccess"

--- a/src/multi-account-create/demo.html
+++ b/src/multi-account-create/demo.html
@@ -8,6 +8,8 @@
 <pre>
 &lt;multi-account-create
   profile-id="..."
+  currency="'EUR'"
+  locale="'fr-FR'"
   on-change="myChangeHandler(model)"
   on-success="mySuccessHandler()"
   on-failure="myFailureHandler()"
@@ -18,6 +20,12 @@
       <dl class="dl-horizontal">
         <dt>profileID</dt>
         <dd>Which profile will own this account.</dd>
+
+        <dt>currency</dt>
+        <dd>Initial currency to select.</dd>
+
+        <dt>locale</dt>
+        <dd>(Optional) Which language should we show? Default: en-GB</dd>
 
         <dt>onChange(model)</dt>
         <dd>(Optional) Triggered every time the model changes.</dd>
@@ -44,10 +52,11 @@
     <div class="col-md-6">
       <multi-account-create
         currency="'EUR'"
+        locale="'fr-FR'"
         profile-id="1234"
-        on-change="$ctrl.onModelChange(model)"
-        on-success="$ctrl.log('demo success')"
-        on-failure="$ctrl.log('demo failure')"
+        on-change="$ctrl.onModelChange"
+        on-success="$ctrl.logSuccess"
+        on-failure="$ctrl.logFailure"
         save-button-label="'Save'"
       ></multi-account-create>
     </div>

--- a/src/multi-account-create/demo.html
+++ b/src/multi-account-create/demo.html
@@ -17,6 +17,14 @@
 &gt;&lt;/multi-account-create&gt;
 </pre>
 
+      <div class="form-group">
+        <label class="control-label">Locale</label>
+        <tw-select
+          options="$ctrl.locales"
+          ng-model="$ctrl.locale">
+        </tw-select>
+      </div>
+
       <dl class="dl-horizontal">
         <dt>profileID</dt>
         <dd>Which profile will own this account.</dd>
@@ -44,14 +52,6 @@
           Localised label for the save button.
         </dd>
       </dl>
-
-      <div class="form-group">
-        <label class="control-label">Locale</label>
-        <tw-select
-          options="$ctrl.locales"
-          ng-model="$ctrl.locale">
-        </tw-select>
-      </div>
 
       <h4>Internal model</h4>
       <pre>{{ $ctrl.model | json }}</pre>

--- a/src/multi-account-create/demo.js
+++ b/src/multi-account-create/demo.js
@@ -2,13 +2,23 @@ import angular from 'angular';
 import template from './demo.html';
 import component from './index';
 
+let ctrl;
+
 class controller {
-  onModelChange(model) {
-    this.model = model;
+  constructor() {
+    ctrl = this;
+    ctrl.model = {};
+  }
+
+  onModelChange(model) { // eslint-disable-line
+    ctrl.model = model;
     console.log('model changed', model); // eslint-disable-line
   }
-  log(message) { // eslint-disable-line
-    console.log(message); // eslint-disable-line
+  logSuccess() { // eslint-disable-line
+    console.log('success'); // eslint-disable-line
+  }
+  logFailure() { // eslint-disable-line
+    onsole.log('failure'); // eslint-disable-line
   }
 }
 

--- a/src/multi-account-create/demo.js
+++ b/src/multi-account-create/demo.js
@@ -27,7 +27,7 @@ class controller {
     console.log('success'); // eslint-disable-line
   }
   logFailure() { // eslint-disable-line
-    onsole.log('failure'); // eslint-disable-line
+    console.log('failure'); // eslint-disable-line
   }
 }
 

--- a/src/multi-account-create/demo.js
+++ b/src/multi-account-create/demo.js
@@ -8,6 +8,15 @@ class controller {
   constructor() {
     ctrl = this;
     ctrl.model = {};
+
+    this.locale = 'en-GB';
+    this.locales = [{
+      value: 'fr-FR',
+      label: 'French'
+    }, {
+      value: 'en-GB',
+      label: 'English'
+    }];
   }
 
   onModelChange(model) { // eslint-disable-line

--- a/src/multi-account-create/multi-account-create.component.js
+++ b/src/multi-account-create/multi-account-create.component.js
@@ -7,9 +7,10 @@ const MultiAccountCreate = {
   bindings: {
     profileId: '<',
     currency: '<',
-    onChange: '&',
-    onSuccess: '&',
-    onFailure: '&',
+    locale: '<',
+    onChange: '<',
+    onSuccess: '<',
+    onFailure: '<',
     saveButtonLabel: '<'
   }
 };

--- a/src/multi-account-create/multi-account-create.controller.js
+++ b/src/multi-account-create/multi-account-create.controller.js
@@ -36,20 +36,22 @@ class MultiAccountCreateController {
       });
   }
 
-  onSaveSuccess() {
-    if (this.onSuccess) {
-      this.onSuccess();
+  // Inthese callback handlers it looks like we should be able to use 'this',
+  // instead of creating the bindings variable, yet when this executes 'this'
+  // is actually pointing to the child 'AccountDetailsCreateController'.
+  // I think webpack must convert this to an arrow function and pass by reference
+  // losing the parent scope.
+  onSaveSuccess() { // eslint-disable-line
+    if (bindings.onSuccess) {
+      bindings.onSuccess();
     }
   }
-  onSaveFailure() {
-    if (this.onFailure) {
-      this.onFailure();
+  onSaveFailure() { // eslint-disable-line
+    if (bindings.onFailure) {
+      bindings.onFailure();
     }
   }
   onDetailsModelChange(model) { // eslint-disable-line
-    // It looks like we should be able to use 'this' instead of creating this
-    // variable, yet when this executes 'this' is actually pointing to the child
-    // 'AccountDetailsCreateController'.  Not sure why...
     if (bindings.onChange) {
       bindings.onChange(model);
     }

--- a/src/multi-account-create/multi-account-create.controller.js
+++ b/src/multi-account-create/multi-account-create.controller.js
@@ -42,19 +42,19 @@ class MultiAccountCreateController {
   // I think webpack must convert this to an arrow function and pass by reference
   // losing the parent scope.
   onSaveSuccess() { // eslint-disable-line
-    if (bindings.onSuccess) {
-      bindings.onSuccess();
-    }
+    triggerCallback(bindings.onSuccess);
   }
   onSaveFailure() { // eslint-disable-line
-    if (bindings.onFailure) {
-      bindings.onFailure();
-    }
+    triggerCallback(bindings.onFailure);
   }
   onDetailsModelChange(model) { // eslint-disable-line
-    if (bindings.onChange) {
-      bindings.onChange(model);
-    }
+    triggerCallback(bindings.onChange, model);
+  }
+}
+
+function triggerCallback(callback, data) {
+  if (typeof callback === 'function') {
+    callback(data);
   }
 }
 

--- a/src/multi-account-create/multi-account-create.controller.js
+++ b/src/multi-account-create/multi-account-create.controller.js
@@ -1,4 +1,6 @@
 
+let bindings;
+
 class MultiAccountCreateController {
   constructor(AccountDetailsService) {
     this.AccountDetailsService = AccountDetailsService;
@@ -10,11 +12,16 @@ class MultiAccountCreateController {
         placeholder: 'Choose currency'
       }
     };
+
+    bindings = this;
   }
 
   $onInit() {
     if (!this.currency) {
       this.currency = 'USD';
+    }
+    if (!this.locale) {
+      this.locale = 'en-GB';
     }
 
     this.currencies = [];
@@ -39,9 +46,12 @@ class MultiAccountCreateController {
       this.onFailure();
     }
   }
-  onModelChange(model) {
-    if (this.onChange) {
-      this.onChange({ model });
+  onDetailsModelChange(model) { // eslint-disable-line
+    // It looks like we should be able to use 'this' instead of creating this
+    // variable, yet when this executes 'this' is actually pointing to the child
+    // 'AccountDetailsCreateController'.  Not sure why...
+    if (bindings.onChange) {
+      bindings.onChange(model);
     }
   }
 }

--- a/src/multi-account-create/multi-account-create.html
+++ b/src/multi-account-create/multi-account-create.html
@@ -11,9 +11,10 @@
 <account-details-create
   profile-id="$ctrl.profileId"
   currency="$ctrl.currency"
+  locale="$ctrl.locale"
   email="$ctrl.email"
-  on-change="$ctrl.onModelChange(model)"
-  on-success="$ctrl.onSaveSuccess()"
-  on-failure="$ctrl.onSaveFailure()"
+  on-change="$ctrl.onDetailsModelChange"
+  on-success="$ctrl.onSaveSuccess"
+  on-failure="$ctrl.onSaveFailure"
   save-button-label="$ctrl.saveButtonLabel">
 </account-details-create>


### PR DESCRIPTION
Adds locale properties allowing us to request localised account details requirements.  (We still lack translation for frontend string).

Changes callbacks from & to < to enable support for a React wrapper at a later date.
